### PR TITLE
#11 カメラロールから選択してもクラッシュしないように修正

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -41,5 +41,11 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSPhotoLibraryUsageDescription</key>
+    <string>This app requires to access your photo library</string>
+    <key>NSCameraUsageDescription</key>
+    <string>This app requires to add file to your camera</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>This app requires to add file to your photo library your microphone</string>
 </dict>
 </plist>

--- a/lib/pages/top.dart
+++ b/lib/pages/top.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:image_cropper/image_cropper.dart';
 import 'package:provider/provider.dart';
+import 'package:camera/camera.dart';
 import 'play.dart';
 import 'dart:async';
 import 'dart:io';
@@ -80,7 +81,7 @@ class _TopScreenState extends State<TopScreen> {
             icon: Icon(Icons.settings),
             onPressed: () async {
               //Navigator.of(context).pushNamed('/setting');
-              
+
               // temporary change on  branch feature/#4
               // TODO: create link for game-play page.
               context.read<PuzzleProvider>().init();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   image_picker: ^0.8.1+3
   image_cropper: ^1.4.1
   provider: ^5.0.0
+  camera: ^0.8.1+7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
許可できていなかったことが原因
<key>NSPhotoLibraryUsageDescription</key>
<string>This app requires to access your photo library</string>
<key>NSCameraUsageDescription</key>
<string>This app requires to add file to your camera</string>
<key>NSMicrophoneUsageDescription</key>
<string>This app requires to add file to your photo library your microphone</string>
上記をInfo.plistに追記することで改善