### PR TITLE
#29: 【修正】サンプルデータの登録処理の変更

### DIFF
--- a/lib/db_provider.dart
+++ b/lib/db_provider.dart
@@ -37,7 +37,10 @@ class DBProvider {
     return await openDatabase(
       path, 
       version: _databaseVersion,
-      onCreate: _createTable,
+      onCreate: (Database database, int version) async {
+        _createTable(database, version);
+        _createSampleData(database, version);
+      }
     );
   }
 
@@ -54,4 +57,35 @@ class DBProvider {
       )
     ''');
   }
+
+  Future<void> _createSampleData(Database database, int version) async {
+    return await database.execute(
+      '''
+      INSERT INTO $tableName ('name', 'width', 'dots', 'last_state', 'is_clear')
+      values (?, ?, ?, ?. ?)
+      ''',
+      [SampleData.name, SampleData.width, SampleData.dots, SampleData.lastState, SampleData.isClear]
+    );
+  }
+}
+
+class SampleData {
+  static const String name = 'sample';
+  static const int width = 10;
+  static const List<int> _dots = [
+    0, 1, 1, 1, 1, 1, 1, 1, 1, 0,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 0, 1, 0, 0, 1, 0, 1, 1,
+    0, 0, 1, 1, 1, 1, 1, 1, 0, 0,
+    0, 1, 1, 1, 1, 1, 1, 1, 1, 0,
+    0, 1, 0, 0, 0, 0, 1, 1, 1, 0,
+    1, 0, 1, 1, 1, 1, 0, 1, 1, 1,
+    1, 0, 1, 1, 1, 1, 0, 1, 1, 1,
+    1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+  ];
+  static String dots = _dots.toString();
+  static List<int> _lastState = List.generate(_dots.length, (_) => 0);
+  static String lastState = _lastState.toString();
+  static const int isClear = 0;
 }

--- a/lib/ui/top/top_view_model.dart
+++ b/lib/ui/top/top_view_model.dart
@@ -10,34 +10,8 @@ class TopViewModel with ChangeNotifier {
 
   void init() async {
     LogicPuzzleDao logicPuzzleDao = LogicPuzzleDao();
-    // ---
-    // TODO: For Debug code. So we must remove it.
-    logicPuzzleDao.deleteAll();
-    var logicPuzzle = LogicPuzzle(
-      name: 'sample', 
-      width: PuzzleData.boardColumnsNum, 
-      dots: PuzzleData.answer, 
-      lastState: List.generate(PuzzleData.answer.length, (_) => 0), 
-      isClear: false);
-    await logicPuzzleDao.create(logicPuzzle);
-    // ---
     logicPuzzles = await logicPuzzleDao.findAll();
     notify();
   }
 }
 
-class PuzzleData {
-  static const List<int> answer = [
-    0, 1, 1, 1, 1, 1, 1, 1, 1, 0,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 0, 1, 0, 0, 1, 0, 1, 1,
-    0, 0, 1, 1, 1, 1, 1, 1, 0, 0,
-    0, 1, 1, 1, 1, 1, 1, 1, 1, 0,
-    0, 1, 0, 0, 0, 0, 1, 1, 1, 0,
-    1, 0, 1, 1, 1, 1, 0, 1, 1, 1,
-    1, 0, 1, 1, 1, 1, 0, 1, 1, 1,
-    1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
-  ];
-  static const int boardColumnsNum = 10;
-}


### PR DESCRIPTION
### 内容
アプリの最初の起動時（DBが存在しない場合）にのみサンプルデータの登録処理を行うように変更。
初期データのためのCREATE TABLE文、INSERT文は別ファイル化（.sqlite3?）が必要になりそう。