### PR TITLE
#43: 【修正】パズルのヒント文字の大きさの最適化

### DIFF
--- a/lib/ui/play/play_screen.dart
+++ b/lib/ui/play/play_screen.dart
@@ -456,7 +456,7 @@ class Puzzle extends StatelessWidget {
         decoration: BoxDecoration(
           color: hintBackgroundColor
         ),
-        child: Center(
+        child: FittedBox(
           child: hintNum != 0
             ? Text(
               '${hintNum}',


### PR DESCRIPTION
### 実装内容
ヒント文字の大きさがパズルサイズに応じて動的に変化するように修正