### PR TITLE
#51: 【リファクタリング】軽量版play画面の実装 

### DIFF
--- a/lib/db_provider.dart
+++ b/lib/db_provider.dart
@@ -34,6 +34,9 @@ class DBProvider {
     String path = join(await getDatabasesPath() , _databaseName);
     // ---
 
+    // Delete the db file.
+    //await deleteDatabase(path);
+
     return await openDatabase(
       path, 
       version: _databaseVersion,
@@ -59,6 +62,14 @@ class DBProvider {
   }
 
   Future<void> _createSampleData(Database database, int version) async {
+    await database.execute(
+      '''
+      INSERT INTO $tableName ('name', 'width', 'dots', 'last_state', 'is_clear')
+      values (?, ?, ?, ?, ?)
+      ''',
+      [SampleData2.name, SampleData2.width, SampleData2.dots, SampleData2.lastState, SampleData2.isClear]
+    );
+
     return await database.execute(
       '''
       INSERT INTO $tableName ('name', 'width', 'dots', 'last_state', 'is_clear')
@@ -83,6 +94,19 @@ class SampleData {
     1, 0, 1, 1, 1, 1, 0, 1, 1, 1,
     1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 
+  ];
+  static String dots = _dots.toString();
+  static List<int> _lastState = List.generate(_dots.length, (_) => 0);
+  static String lastState = _lastState.toString();
+  static const int isClear = 0;
+}
+
+class SampleData2 {
+  static const String name = 'sample2';
+  static const int width = 2;
+  static const List<int> _dots = [
+    0, 1,
+    1, 0
   ];
   static String dots = _dots.toString();
   static List<int> _lastState = List.generate(_dots.length, (_) => 0);

--- a/lib/service/puzzle_painter.dart
+++ b/lib/service/puzzle_painter.dart
@@ -1,0 +1,427 @@
+import 'dart:math';
+
+import 'package:ant_1/domain/entities/logic_puzzle.dart';
+import 'package:flutter/material.dart';
+
+class PuzzlePainter extends CustomPainter {
+  final BuildContext context;
+  final LogicPuzzle logicPuzzle;
+  PuzzlePainter({this.context, this.logicPuzzle});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    drawBorderArea(canvas);
+    drawViewArea(canvas);
+    drawColumnHintsArea(canvas);
+    drawRowHintsArea(canvas);
+    drawBoardArea(canvas);
+    drawLastState(canvas);
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) {
+    return false;
+  }
+
+  List<int> get answer => logicPuzzle.dots;
+  int get boardColumnsNum => logicPuzzle.width;
+  int get boardRowsNum => answer.length ~/ boardColumnsNum;
+  List<int> get hintsInEachRow => _hintsInEachRow();
+  int get _maxNumOfHintsInEachRow => hintsInEachRow.length ~/ boardRowsNum;
+  int get maxNumOfHintsInEachRow => _maxNumOfHintsInEachRow > 0 ? _maxNumOfHintsInEachRow : 1;
+  List<int> get hintsInEachColumn => _hintsInEachColumn();
+  int get _maxNumOfHintsInEachColumn => hintsInEachColumn.length ~/ boardColumnsNum;
+  int get maxNumOfHintsInEachColumn => _maxNumOfHintsInEachColumn > 0 ? _maxNumOfHintsInEachColumn : 1;
+
+  List<int> _hintsInEachRow() {
+    List<List<int>> hints = [];
+    List<int> tmp;
+    int pre;
+    int n;
+    int maxN = 0;
+    for (int i = 0; i < boardColumnsNum; i++) {
+      tmp = [];
+      pre = 0;
+      n = 0;
+      for (int j = 0; j < boardRowsNum; j++) {
+        int now = answer[boardRowsNum * i + j];
+        if (now == 0) {
+          if (pre == 1) {
+            tmp.add(n);
+          }
+          n = 0;
+          pre = 0;
+        } else {
+          n++;
+          pre = 1;
+        }
+      }
+      if (n != 0) {
+        tmp.add(n);
+      }
+      maxN = max(maxN, tmp.length);
+      hints.add(tmp.reversed.toList());
+    }
+
+    List<int> result = List.generate(maxN * boardColumnsNum, (_) => 0);
+    for (int i = 0; i < boardColumnsNum; i++) {
+      List<int> hint = hints[i];
+      for (int j = 0; j < hint.length; j++) {
+        result[maxN * (i + 1) - j - 1] = hint[j];
+      }
+    }
+
+    return result;
+  }
+
+  List<int> _hintsInEachColumn() {
+    List<List<int>> hints = [];
+    List<int> tmp;
+    int pre;
+    int n;
+    int maxN = 0;
+    for (int i = 0; i < boardRowsNum; i++) {
+      tmp = [];
+      pre = 0;
+      n = 0;
+      for (int j = 0; j < boardColumnsNum; j++) {
+        int now = answer[boardRowsNum * j + i];
+        if (now == 0) {
+          if (pre == 1) {
+            tmp.add(n);
+          }
+          n = 0;
+          pre = 0;
+        } else {
+          n++;
+          pre = 1;
+        }
+      }
+      if (n != 0) {
+        tmp.add(n);
+      }
+      maxN = max(maxN, tmp.length);
+      hints.add(tmp.reversed.toList());
+    }
+
+    List<int> result = List.generate(maxN * boardRowsNum, (_) => 0);
+    for (int i = 0; i < boardRowsNum; i++) {
+      List<int> hint = hints[i];
+      for (int j = 0; j < hint.length; j++) {
+        result[maxN * (i + 1) - j - 1] = hint[j];
+      }
+    }
+
+    return result;
+  }
+
+  Color borderColor = PuzzleSetting.borderColor;
+  Color hintBackgroundColor = PuzzleSetting.hintBackgroundColor;
+  Color hintTextColor = PuzzleSetting.hintTextColor;
+  Color markedColor = PuzzleSetting.markedColor;
+  Color nonMarkedColor = PuzzleSetting.nonMarkedColor;
+
+  double get _screenWidth => MediaQuery.of(context).size.width;
+  double get _screenHeight => MediaQuery.of(context).size.height;
+  double get _puzzleWidth => _borderLayerWidth;
+  double get _puzzleHeight => _borderLayerHeight;
+  double get ratioOfScreenToPuzzle =>
+    _screenWidth / _puzzleWidth < _screenHeight / _puzzleHeight
+    ? _screenWidth / _borderLayerWidth
+    : _screenHeight / _borderLayerHeight;
+
+  final double _squareSize = PuzzleSetting.squareSize;
+  double get squareSize => _squareSize * ratioOfScreenToPuzzle;
+  final double _borderWidth = PuzzleSetting.borderWidth;
+  double get borderWidth => _borderWidth * ratioOfScreenToPuzzle;
+  final double _boldBorderWidth = PuzzleSetting.boldBorderWidth;
+  double get boldBorderWidth => _boldBorderWidth * ratioOfScreenToPuzzle;
+  final int boldBorderInterval = PuzzleSetting.boldBorderInterval;
+
+  double get _borderLayerWidth =>
+    _boldBorderWidth +
+    maxNumOfHintsInEachRow * _squareSize +
+    (maxNumOfHintsInEachRow - 1) * _borderWidth + 
+    _boldBorderWidth +
+    boardColumnsNum * _squareSize +
+    (boardColumnsNum - ((boardColumnsNum - 1) ~/ boldBorderInterval) - 1) * _borderWidth + 
+    ((boardColumnsNum - 1) ~/ boldBorderInterval) * _boldBorderWidth +
+    _boldBorderWidth;
+  double get borderLayerWidth => _borderLayerWidth * ratioOfScreenToPuzzle;
+  double get _borderLayerHeight =>
+    _boldBorderWidth +
+    maxNumOfHintsInEachColumn * _squareSize +
+    (maxNumOfHintsInEachColumn - 1) * _borderWidth + 
+    _boldBorderWidth +
+    boardRowsNum * _squareSize +
+    (boardRowsNum - ((boardRowsNum - 1) ~/ boldBorderInterval) - 1) * _borderWidth + 
+    ((boardRowsNum - 1) ~/ boldBorderInterval) * _boldBorderWidth +
+    _boldBorderWidth;
+  double get borderLayerHeight => _borderLayerHeight * ratioOfScreenToPuzzle;
+  Offset get borderLayerOffset => Offset(0, 0);
+  Size get borderLayerSize => Size(borderLayerWidth, borderLayerHeight);
+  void drawBorderArea(Canvas canvas) {
+    drawSquare(canvas, borderLayerOffset, borderLayerSize, PaintingStyle.fill, borderColor, 0);
+  }
+
+  double get viewAreaLeftOffset => _boldBorderWidth * ratioOfScreenToPuzzle;
+  double get viewAreaTopOffset => _boldBorderWidth * ratioOfScreenToPuzzle;
+  Offset get viewAreaOffset => Offset(viewAreaLeftOffset, viewAreaTopOffset);
+  double get viewAreaWidth => (maxNumOfHintsInEachRow.toDouble() * _squareSize + (maxNumOfHintsInEachRow.toDouble() - 1) * _borderWidth) * ratioOfScreenToPuzzle;
+  double get viewAreaHeight => (maxNumOfHintsInEachColumn.toDouble() * _squareSize + (maxNumOfHintsInEachColumn.toDouble() - 1) * _borderWidth) * ratioOfScreenToPuzzle;
+  Size get viewAreaSize => Size(viewAreaWidth, viewAreaHeight);
+  void drawViewArea(Canvas canvas) {
+    drawSquare(canvas, viewAreaOffset, viewAreaSize, PaintingStyle.fill, nonMarkedColor, 0);
+    drawLastStateInViewArea(canvas);
+  }
+
+  int get _columnHintsAreaBoldBorderNum => (boardColumnsNum - 1) ~/ boldBorderInterval;
+  int get _columnHintsAreaBorderNum => boardColumnsNum - _columnHintsAreaBoldBorderNum - 1;
+  double get columnHintsAreaLeftOffset => viewAreaLeftOffset + viewAreaWidth + _boldBorderWidth * ratioOfScreenToPuzzle;
+  double get columnHintsAreaTopOffset => _boldBorderWidth * ratioOfScreenToPuzzle;
+  Offset get columnHintsAreaOffset => Offset(columnHintsAreaLeftOffset, columnHintsAreaTopOffset);
+  double get columnHintsAreaWidth => (_squareSize * boardColumnsNum.toDouble() + _borderWidth * _columnHintsAreaBorderNum + _boldBorderWidth * _columnHintsAreaBoldBorderNum) * ratioOfScreenToPuzzle;
+  double get columnHintsAreaHeight => (maxNumOfHintsInEachColumn.toDouble() * _squareSize + (maxNumOfHintsInEachColumn.toDouble() - 1) * _borderWidth) * ratioOfScreenToPuzzle;
+  Size get columnHiintsAreraSize => Size(columnHintsAreaWidth, columnHintsAreaHeight);
+  void drawColumnHintsArea(Canvas canvas) {
+    Size size = Size(squareSize, squareSize);
+    for (int i = 0; i < boardColumnsNum; i++) {
+      for (int j = 0; j < maxNumOfHintsInEachColumn; j++) {
+        Offset offset = Offset(
+          columnHintsAreaLeftOffset + squareSize * i + borderWidth * (i - i ~/ boldBorderInterval) + boldBorderWidth * (i ~/ boldBorderInterval),
+          columnHintsAreaTopOffset + (squareSize + borderWidth) * j
+        );
+        drawSquare(canvas, offset, size, PaintingStyle.fill, hintBackgroundColor, 0);
+        int hintNum = hintsInEachColumn[maxNumOfHintsInEachColumn * i + j];
+        String hintText = hintNum > 0 ? '$hintNum' : ''; 
+        drawHintText(canvas, offset, size, hintText);
+      }
+    }
+  }
+
+  int get _rowHintsAreaBoldBorderNum => (boardRowsNum - 1) ~/ boldBorderInterval;
+  int get _rowHintsAreaBorderNum => boardColumnsNum - _rowHintsAreaBoldBorderNum - 1;
+  double get rowHintsAreaLeftOffset => _boldBorderWidth * ratioOfScreenToPuzzle;
+  double get rowHintsAreaTopOffset => viewAreaTopOffset + viewAreaHeight + _boldBorderWidth * ratioOfScreenToPuzzle;
+  Offset get rowHintsAreaOffset => Offset(rowHintsAreaLeftOffset, rowHintsAreaTopOffset);
+  double get rowHintsAreaWidth => (maxNumOfHintsInEachRow.toDouble() * _squareSize + (maxNumOfHintsInEachRow.toDouble() - 1) * _borderWidth) * ratioOfScreenToPuzzle;
+  double get rowHintsAreaHeight => (_squareSize * boardRowsNum.toDouble() + _borderWidth * _rowHintsAreaBorderNum + _boldBorderWidth * _rowHintsAreaBorderNum) * ratioOfScreenToPuzzle;
+  Size get rowHintsAreaSize => Size(rowHintsAreaWidth, rowHintsAreaHeight);
+  void drawRowHintsArea(Canvas canvas) {
+    Size size = Size(squareSize, squareSize);
+    for (int i = 0; i < maxNumOfHintsInEachRow; i++) {
+      for (int j = 0; j < boardRowsNum; j++) {
+        Offset offset = Offset(
+          rowHintsAreaLeftOffset + (squareSize + borderWidth) * i,
+          rowHintsAreaTopOffset + squareSize * j + borderWidth * (j - j ~/ boldBorderInterval) + boldBorderWidth * (j ~/ boldBorderInterval)
+        );
+        drawSquare(canvas, offset, size, PaintingStyle.fill, hintBackgroundColor, 0);
+        int hintNum = hintsInEachRow[maxNumOfHintsInEachColumn * j + i];
+        String hintText = hintNum > 0 ? '$hintNum' : ''; 
+        drawHintText(canvas, offset, size, hintText);
+      }
+    }
+  }
+
+  int get _boardAreaRowBoldBorderNum => (boardColumnsNum - 1) ~/ boldBorderInterval;
+  int get _boardAreaColumnBoldBorderNum => (boardRowsNum - 1) ~/ boldBorderInterval;
+  int get _boardAreaRowBorderNum => boardColumnsNum - _boardAreaRowBoldBorderNum - 1;
+  int get _boardAreaColumnBorderNum => boardRowsNum - _boardAreaColumnBoldBorderNum - 1;
+  double get boardAreaLeftOffset => rowHintsAreaLeftOffset + rowHintsAreaWidth + _boldBorderWidth * ratioOfScreenToPuzzle;
+  double get boardAreaTopOffset => columnHintsAreaTopOffset + columnHintsAreaHeight + _boldBorderWidth * ratioOfScreenToPuzzle;
+  Offset get boardAreaOffset => Offset(boardAreaLeftOffset, boardAreaTopOffset);
+  double get boardAreaWidth => (_squareSize * boardColumnsNum.toDouble() + borderWidth * _boardAreaRowBorderNum + boldBorderWidth * _boardAreaRowBoldBorderNum) * ratioOfScreenToPuzzle;
+  double get boardAreaHeight => (_squareSize * boardRowsNum.toDouble() + borderWidth * _boardAreaColumnBorderNum + boldBorderWidth * _boardAreaColumnBoldBorderNum) * ratioOfScreenToPuzzle;
+  Size get boardAreaSize => Size(boardAreaWidth, boardAreaHeight);
+  void drawBoardArea(Canvas canvas) {
+    Size size = Size(squareSize, squareSize);
+    for (int i = 0; i < boardColumnsNum; i++) {
+      for (int j = 0; j < boardRowsNum; j++) {
+        Offset offset = Offset(
+          boardAreaLeftOffset + squareSize * i + borderWidth * (i - i ~/ boldBorderInterval) + boldBorderWidth * (i ~/ boldBorderInterval),
+          boardAreaTopOffset + squareSize * j + borderWidth * (j - j ~/ boldBorderInterval) + boldBorderWidth * (j ~/ boldBorderInterval)
+        );
+        drawSquare(canvas, offset, size, PaintingStyle.fill, nonMarkedColor, 0);
+      }
+    }
+  }
+
+  void drawLastState(Canvas canvas) {
+    for (int j = 0; j < boardRowsNum; j++) {
+      for (int i = 0; i < boardColumnsNum; i++) {
+        int index = boardColumnsNum * j + i;
+        int state = logicPuzzle.lastState[index];
+        drawState(canvas, index, state);
+      }
+    }
+  }
+
+  void drawState(Canvas canvas, int index, int state) {
+    Size size = Size(squareSize, squareSize);
+    int puzzleWidth = logicPuzzle.width;
+
+    int i = index % puzzleWidth;
+    int j = index ~/ puzzleWidth;
+
+    Offset offset = Offset(
+      boardAreaLeftOffset + squareSize * i + borderWidth * (i - i ~/ boldBorderInterval) + boldBorderWidth * (i ~/ boldBorderInterval),
+      boardAreaTopOffset + squareSize * j + borderWidth * (j - j ~/ boldBorderInterval) + boldBorderWidth * (j ~/ boldBorderInterval)
+    );
+    
+    drawSquare(canvas, offset, size, PaintingStyle.fill, nonMarkedColor, 0);
+    switch (state) {
+      case 0:
+        break;
+      case 1:
+        drawMarked1(canvas, offset, size, markedColor, 0);
+        break;
+      case 2:
+        drawMarked2(canvas, offset, size, markedColor, borderWidth);
+        break;
+    }
+  }
+
+  double get drawAreaInViewAreaWidth => min(viewAreaWidth, viewAreaHeight) * 0.9;
+  double get drawAreaInViewAreaHeight => min(viewAreaWidth, viewAreaHeight) * 0.9;
+  Size get drawAreaInViewAreaSize => Size(drawAreaInViewAreaWidth, drawAreaInViewAreaHeight);
+  double get drawAreaInViewAreaLeftOffset => viewAreaLeftOffset + (viewAreaWidth - drawAreaInViewAreaWidth) / 2;
+  double get drawAreaInViewAreaTopOffset => viewAreaTopOffset + (viewAreaHeight - drawAreaInViewAreaHeight) / 2;
+  Offset get drawAreaInViewAreaOffset => Offset(drawAreaInViewAreaLeftOffset, drawAreaInViewAreaTopOffset);
+  Size get drawAreaInViewAreaSquareSize => drawAreaInViewAreaSize / max(boardColumnsNum.toDouble(), boardRowsNum.toDouble());
+  void drawLastStateInViewArea(Canvas canvas) {
+    for (int i = 0; i < boardColumnsNum; i++) {
+      for (int j = 0; j < boardRowsNum; j++) {
+        int index = boardColumnsNum * j + i;
+        int state = logicPuzzle.lastState[index];
+        drawStateInViewArea(canvas, index, state);
+      }
+    }
+  }
+
+  void drawStateInViewArea(Canvas canvas, int index, int state) {
+    int puzzleWidth = logicPuzzle.width;
+    int i = index % puzzleWidth;
+    int j = index ~/ puzzleWidth;
+
+    Offset offset = Offset(
+      drawAreaInViewAreaLeftOffset + drawAreaInViewAreaSquareSize.width * i,
+      drawAreaInViewAreaTopOffset + drawAreaInViewAreaSquareSize.height * j
+    );
+    Size size = drawAreaInViewAreaSquareSize;
+
+    double padding1 = size.width * 0.01;
+    Offset offset1 = offset + Offset(padding1, padding1) / 2;
+    Size size1 = size * 0.99;
+    double padding2 = size.width * 0.1;
+    Offset offset2 = offset + Offset(padding2, padding2) / 2;
+    Size size2 = size * 0.9;
+
+    drawSquare(canvas, offset1, size1, PaintingStyle.fill, nonMarkedColor, 0);
+    switch (state) {
+      case 0:
+        break;
+      case 1:
+        drawSquare(canvas, offset2, size2, PaintingStyle.fill, markedColor, 0);
+        break;
+      case 2:
+        break;
+    }
+  }
+
+  void drawSquare(Canvas canvas, Offset offset, Size size, PaintingStyle style, Color color, double strokeWidth) {
+    Paint paint = Paint()
+      ..color = color
+      ..strokeCap = StrokeCap.butt
+      ..style = style
+      ..strokeWidth = strokeWidth;
+    
+    Path path = Path();
+    path.moveTo(offset.dx, offset.dy);
+    path.lineTo(offset.dx, offset.dy + size.height);
+    path.lineTo(offset.dx + size.width, offset.dy + size.height);
+    path.lineTo(offset.dx + size.width, offset.dy);
+    path.close();
+
+    canvas.drawPath(path, paint);
+  }
+
+  void drawMarked1(Canvas canvas, Offset offset, Size size, Color color, double strokeWidth) {
+    double padding = squareSize * 0.9;
+    Offset filledSquareOffset = Offset(
+      offset.dx + padding,
+      offset.dy + padding
+    );
+    Size filledSquareSize = Size(
+      size.width - padding * 2,
+      size.height - padding * 2 
+    );
+    drawSquare(canvas, filledSquareOffset, filledSquareSize, PaintingStyle.fill, color, 0);
+  }
+
+  void drawMarked2(Canvas canvas, Offset offset, Size size, Color color, double strokeWidth) {
+    double padding = squareSize * 0.9;
+    Paint paint = Paint()
+      ..color = color
+      ..strokeCap = StrokeCap.butt
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth;
+    
+    Offset checkedMarkOffset = Offset(
+      offset.dx + padding,
+      offset.dy + padding
+    );
+    Size checkedMarkSize = Size(
+      size.width - padding * 2,
+      size.height - padding * 2 
+    );
+
+    Path path = Path();
+    path.moveTo(checkedMarkOffset.dx, checkedMarkOffset.dy);
+    path.lineTo(checkedMarkOffset.dx + checkedMarkSize.width, checkedMarkOffset.dy + checkedMarkSize.height);
+    path.close();
+    
+    Path path2 = Path();
+    path.moveTo(checkedMarkOffset.dx, checkedMarkOffset.dy + checkedMarkSize.height);
+    path.lineTo(checkedMarkOffset.dx + checkedMarkSize.width, checkedMarkOffset.dy);
+   
+    canvas.drawPath(path, paint);
+    canvas.drawPath(path2, paint);
+  }
+
+  void drawHintText(Canvas canvas, Offset squareOffset, Size squareSize, String text) {
+    TextStyle textStyle = TextStyle(
+      color: hintTextColor,
+      fontSize: squareSize.width * 0.9,
+    );
+    TextSpan textSpan = TextSpan(
+      style: textStyle,
+      children: <TextSpan>[
+        TextSpan(text: text),
+      ]
+    );
+    TextPainter textPainter = TextPainter(
+      text: textSpan,
+      textDirection: TextDirection.ltr
+    );
+    textPainter.layout();
+    Offset offset = squareOffset 
+      - Offset(textPainter.width/2.0, textPainter.height/2.0) 
+      + Offset(squareSize.width/2.0, squareSize.height/2.0);
+    textPainter.paint(canvas, offset);
+  }
+}
+
+class PuzzleSetting {
+  // TODO: move to settinig(const variables) file
+  static const double squareSize = 10.0;
+  static const double borderWidth = 0.8;
+  static const double boldBorderWidth = 1.5;
+  static const int boldBorderInterval = 5;
+  static const Color borderColor = Colors.black;
+  //static final Color hintBackgroundColor = Colors.blue[50];
+  static const Color hintBackgroundColor = Color(0xFFE3F2FD);
+  static const Color hintTextColor = Colors.black;
+  //static final Color markedColor = Colors.blue[500];
+  static const Color markedColor = Color(0xFF2196F3);
+  static const Color nonMarkedColor = Colors.white;
+}

--- a/lib/service/utils.dart
+++ b/lib/service/utils.dart
@@ -1,0 +1,11 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+Future<ui.Image> getImageFromPainter(CustomPainter painter, Size size) async {
+    final ui.PictureRecorder recorder = ui.PictureRecorder();
+    painter.paint(Canvas(recorder), size);
+    final ui.Picture picture = recorder.endRecording();
+    final ui.Image image = await picture.toImage(size.width.toInt(), size.height.toInt());
+    return image;
+  }

--- a/lib/ui/play/play_screen.dart
+++ b/lib/ui/play/play_screen.dart
@@ -88,10 +88,8 @@ class PlayScreen extends StatelessWidget {
                   child: Container(
                     child: Transform.translate(
                       offset: model.offset,
-                      // offset: Offset(0,0),
                       child: Transform.scale(
-                        scale: 0.9,
-                        // scale: model.scale,
+                        scale: model.scale,
                         child: child,
                       ),
                     ),

--- a/lib/ui/play/play_screen.dart
+++ b/lib/ui/play/play_screen.dart
@@ -1,14 +1,23 @@
-import 'dart:math';
+import 'dart:ui' as ui;
 
 import 'package:ant_1/domain/entities/logic_puzzle.dart';
+import 'package:ant_1/service/utils.dart';
+import 'package:ant_1/service/puzzle_painter.dart';
 import 'package:ant_1/ui/play/play_view_model.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:flutter/foundation.dart';
+
 
 class PlayScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<PlayViewModel>().isBuildedOnce = true;
+    });
+
+    final GlobalKey customPaintWidgetKey = GlobalKey();
+    final GlobalKey customPaintWidgetKey2 = GlobalKey();
     LogicPuzzle logicPuzzle = context.read<PlayViewModel>().logicPuzzle;
 
     return Scaffold(
@@ -16,52 +25,143 @@ class PlayScreen extends StatelessWidget {
         title: Text('${logicPuzzle.name}'),
         automaticallyImplyLeading: false,
       ),
-      body: Consumer<PlayViewModel>(builder: (context, model, _) {
-        return GestureDetector(
-          onScaleStart: (details) {
-            model.initialFocalPoint = details.focalPoint;
-          },
-          onScaleUpdate: (details) async {
-            model.sessionOffset = details.focalPoint - model.initialFocalPoint;
-            model.initialFocalPoint = details.focalPoint;
-            model.offset += model.sessionOffset;
+      body: Consumer<PlayViewModel>(
+        builder: (context, model, child) {
+          return GestureDetector(
+            onScaleStart: (details) {
+              model.initialFocalPoint = details.focalPoint;
+            },
+            onScaleUpdate: (details) async {
+              model.sessionOffset = details.focalPoint - model.initialFocalPoint;
+              model.initialFocalPoint = details.focalPoint;
+              model.offset += model.sessionOffset;
 
-            model.scale *= details.scale;
-            if (model.scale < 0.5) {
-              model.scale = 0.5;
-            }
-            if (model.scale > 1.5) {
-              model.scale = 1.5;
-            }
+              model.scale *= details.scale;
+              if (model.scale < 0.5) {
+                model.scale = 0.5;
+              }
+              if (model.scale > 1.5) {
+                model.scale = 1.5;
+              }
 
-            model.notify();
-          },
-          onScaleEnd: (details) {
-            // nothing
-          },
-          child: Column(
-            children: <Widget>[
-              Expanded(
-                child: Container(
-                  child: Transform.translate(
-                    offset: model.offset,
-                    child: Transform.scale(
-                      scale: model.scale,
-                      child: Puzzle(
-                        context: context,
-                        logicPuzzle: logicPuzzle,
+              model.notify();
+            },
+            onScaleEnd: (details) {
+              // nothing
+            },
+            onTapDown: (details) {
+              Offset tapOffset = details.globalPosition;
+              RenderBox box;
+              if (!model.isDrawImage) {
+                box = customPaintWidgetKey.currentContext.findRenderObject();
+              } else {
+                box = customPaintWidgetKey2.currentContext.findRenderObject();
+              }
+              Offset customPaintOffset = box.localToGlobal(Offset.zero);
+
+              for (int index = 0; index < logicPuzzle.dots.length; index++) {
+                Offset upperLeftOffset = model.inputSquareLocalPointsList[index][0] * model.scale + customPaintOffset;
+                Offset lowerRightOffset = model.inputSquareLocalPointsList[index][1] * model.scale + customPaintOffset;
+                if (upperLeftOffset <= tapOffset && tapOffset <= lowerRightOffset) {
+                  if (model.logicPuzzle.lastState[index] == 0) {                
+                    switch (model.operationMethodIndex) {
+                      case 0:
+                        model.logicPuzzle.lastState[index] = 1;
+                        break;
+                      case 1:
+                        model.logicPuzzle.lastState[index] = 2;
+                        break;
+                    }
+                  } else {
+                    model.logicPuzzle.lastState[index] = 0;
+                  }
+                  model.tappedSquaeIndex = index;
+                  model.save();
+                  model.notify();
+                  break;
+                }
+              }
+            },
+            child: Column(
+              children: <Widget>[
+                Expanded(
+                  child: Container(
+                    child: Transform.translate(
+                      offset: model.offset,
+                      // offset: Offset(0,0),
+                      child: Transform.scale(
+                        scale: 0.9,
+                        // scale: model.scale,
+                        child: child,
                       ),
                     ),
                   ),
                 ),
-              ),
-              OperationBar(
-                context: context,
-              ),
-            ],
-          ),
+                OperationBar(
+                  context: context,
+                ),
+              ],
+            ),
+          );
+        },
+        child: Consumer<PlayViewModel>(
+          builder: (context, model, _) {
+            return Stack(
+              children: [
+                if(!model.isBuildedOnce) buildInitPuzzle(context, customPaintWidgetKey),
+                if(model.isBuildedOnce) buildPuzzle(context, customPaintWidgetKey2),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget buildInitPuzzle(BuildContext context, GlobalKey widgetKey) {
+    Size size = Size(MediaQuery.of(context).size.width, MediaQuery.of(context).size.width);
+    PuzzleInitPainter painter = PuzzleInitPainter(
+      context: context,
+      state: context.read<PlayViewModel>().logicPuzzle.lastState,
+    );   
+
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      context.read<PlayViewModel>().puzzleImage = await getImageFromPainter(painter, size);
+    });
+    
+    return RepaintBoundary(
+      key: widgetKey,
+      child: CustomPaint(
+        size: size,
+        painter: painter,
+        isComplex: true,
+        willChange: false,
+      ),
+    );
+  }
+
+  Widget buildPuzzle(BuildContext context, GlobalKey widgetKey) {
+    return Consumer<PlayViewModel>(
+      builder: (context, model, child) {
+        Size size = Size(MediaQuery.of(context).size.width, MediaQuery.of(context).size.width);
+        PuzzleUpdatePainter painter = PuzzleUpdatePainter(
+          context: context,
+          state: model.logicPuzzle.lastState
         );
-      }),
+        if(context.read<PlayViewModel>().isBuildedOnce && model.tappedSquaeIndex != null) {
+          WidgetsBinding.instance.addPostFrameCallback((_) async {
+            context.read<PlayViewModel>().puzzleImage = await getImageFromPainter(painter, size);
+            context.read<PlayViewModel>().tappedSquaeIndex = null;
+          });
+        }
+
+        return CustomPaint(
+          key: widgetKey,
+          size: size,
+          painter: painter,
+          child: Center(),
+        );
+      }
     );
   }
 }
@@ -171,363 +271,16 @@ class OperationBar extends StatelessWidget {
   }
 }
 
-class Puzzle extends StatelessWidget {
+class PuzzleInitPainter extends PuzzlePainter {
   final BuildContext context;
-  final LogicPuzzle logicPuzzle;
-  Puzzle({this.context, this.logicPuzzle});
+  final List<int> state;
+  PuzzleInitPainter({this.context, this.state}) : super(context: context, logicPuzzle: context.read<PlayViewModel>().logicPuzzle); 
 
   @override
-  Widget build(BuildContext context) {
-    //context.read<PlayController>().checkedList.removeWhere((_) => true);
+  void paint(Canvas canvas, Size size) {
+    super.paint(canvas, size);
     context.read<PlayViewModel>().isCorrect = isCorrect;
-
-    return Stack(
-      fit: StackFit.loose,
-      children: <Widget>[
-        buildBorderArea(),
-        buildViewArea(),
-        buildColumnHintsArea(),
-        buildRowHintsArea(),
-        buildBoardArea(),
-      ],
-    );
-  }
-
-  List<int> get answer => logicPuzzle.dots;
-  int get boardColumnsNum => logicPuzzle.width;
-  int get boardRowsNum => answer.length ~/ boardColumnsNum;
-  List<int> get hintsInEachRow => _hintsInEachRow();
-  int get _maxNumOfHintsInEachRow => hintsInEachRow.length ~/ boardRowsNum;
-  int get maxNumOfHintsInEachRow => _maxNumOfHintsInEachRow > 0 ? _maxNumOfHintsInEachRow : 1;
-  List<int> get hintsInEachColumn => _hintsInEachColumn();
-  int get _maxNumOfHintsInEachColumn => hintsInEachColumn.length ~/ boardColumnsNum;
-  int get maxNumOfHintsInEachColumn => _maxNumOfHintsInEachColumn > 0 ? _maxNumOfHintsInEachColumn : 1;
-
-  List<int> _hintsInEachRow() {
-    List<List<int>> hints = [];
-    List<int> tmp;
-    int pre;
-    int n;
-    int maxN = 0;
-    for (int i = 0; i < boardColumnsNum; i++) {
-      tmp = [];
-      pre = 0;
-      n = 0;
-      for (int j = 0; j < boardRowsNum; j++) {
-        int now = answer[boardRowsNum * i + j];
-        if (now == 0) {
-          if (pre == 1) {
-            tmp.add(n);
-          }
-          n = 0;
-          pre = 0;
-        } else {
-          n++;
-          pre = 1;
-        }
-      }
-      if (n != 0) {
-        tmp.add(n);
-      }
-      maxN = max(maxN, tmp.length);
-      hints.add(tmp.reversed.toList());
-    }
-
-    List<int> result = List.generate(maxN * boardColumnsNum, (_) => 0);
-    for (int i = 0; i < boardColumnsNum; i++) {
-      List<int> hint = hints[i];
-      for (int j = 0; j < hint.length; j++) {
-        result[maxN * (i + 1) - j - 1] = hint[j];
-      }
-    }
-
-    return result;
-  }
-
-  List<int> _hintsInEachColumn() {
-    List<List<int>> hints = [];
-    List<int> tmp;
-    int pre;
-    int n;
-    int maxN = 0;
-    for (int i = 0; i < boardRowsNum; i++) {
-      tmp = [];
-      pre = 0;
-      n = 0;
-      for (int j = 0; j < boardColumnsNum; j++) {
-        int now = answer[boardRowsNum * j + i];
-        if (now == 0) {
-          if (pre == 1) {
-            tmp.add(n);
-          }
-          n = 0;
-          pre = 0;
-        } else {
-          n++;
-          pre = 1;
-        }
-      }
-      if (n != 0) {
-        tmp.add(n);
-      }
-      maxN = max(maxN, tmp.length);
-      hints.add(tmp.reversed.toList());
-    }
-
-    List<int> result = List.generate(maxN * boardRowsNum, (_) => 0);
-    for (int i = 0; i < boardRowsNum; i++) {
-      List<int> hint = hints[i];
-      for (int j = 0; j < hint.length; j++) {
-        result[maxN * (i + 1) - j - 1] = hint[j];
-      }
-    }
-
-    return result;
-  }
-
-  double get _screenWidth => MediaQuery.of(context).size.width;
-  double get _screenHeight => MediaQuery.of(context).size.height;
-  double get _puzzleWidth => _borderLayerWidth;
-  double get _puzzleHeight => _borderLayerHeight;
-  double get ratioOfScreenToPuzzle =>
-    _screenWidth / _puzzleWidth < _screenHeight / _puzzleHeight
-    ? _screenWidth / _borderLayerWidth
-    : _screenHeight / _borderLayerHeight;
-
-  final double _squareSize = PuzzleSetting.squareSize;
-  double get squareSize => _squareSize * ratioOfScreenToPuzzle;
-  final double _borderWidth = PuzzleSetting.borderWidth;
-  double get borderWidth => _borderWidth * ratioOfScreenToPuzzle;
-  final double _boldBorderWidth = PuzzleSetting.boldBorderWidth;
-  double get boldBorderWidth => _boldBorderWidth * ratioOfScreenToPuzzle;
-  final int boldBorderInterval = PuzzleSetting.boldBorderInterval;
-
-  Color borderColor = PuzzleSetting.borderColor;
-  Color boldBorderColor = PuzzleSetting.boldBorderColor;
-  Color hintBackgroundColor = PuzzleSetting.hintBackgroundColor;
-  Color markedColor = PuzzleSetting.markedColor;
-  Color nonMarkedColor = PuzzleSetting.nonMarkedColor;
-
-  double get _borderLayerWidth =>
-    _boldBorderWidth +
-    maxNumOfHintsInEachRow * _squareSize +
-    (maxNumOfHintsInEachRow - 1) * _borderWidth + 
-    _boldBorderWidth +
-    boardColumnsNum * _squareSize +
-    (boardColumnsNum - ((boardColumnsNum - 1) ~/ boldBorderInterval) - 1) * _borderWidth + 
-    ((boardColumnsNum - 1) ~/ boldBorderInterval) * _boldBorderWidth +
-    _boldBorderWidth;
-  double get borderLayerWidth => _borderLayerWidth * ratioOfScreenToPuzzle;
-  double get _borderLayerHeight =>
-    _boldBorderWidth +
-    maxNumOfHintsInEachColumn * _squareSize +
-    (maxNumOfHintsInEachColumn - 1) * _borderWidth + 
-    _boldBorderWidth +
-    boardRowsNum * _squareSize +
-    (boardRowsNum - ((boardRowsNum - 1) ~/ boldBorderInterval) - 1) * _borderWidth + 
-    ((boardRowsNum - 1) ~/ boldBorderInterval) * _boldBorderWidth +
-    _boldBorderWidth;
-  double get borderLayerHeight => _borderLayerHeight * ratioOfScreenToPuzzle;
-  Widget buildBorderArea() {
-    return Positioned(
-      left: 0,
-      top: 0,
-      width: borderLayerWidth,
-      height: borderLayerHeight,
-      child: Container(
-        color: boldBorderColor,
-      ),
-    );
-  }
-
-  double get viewAreaLeftOffset => _boldBorderWidth * ratioOfScreenToPuzzle;
-  double get viewAreaTopOffset => _boldBorderWidth * ratioOfScreenToPuzzle;
-  double get viewAreaWidth => (maxNumOfHintsInEachRow.toDouble() * _squareSize + (maxNumOfHintsInEachRow.toDouble() - 1) * _borderWidth) * ratioOfScreenToPuzzle;
-  double get viewAreaHeight => (maxNumOfHintsInEachColumn.toDouble() * _squareSize + (maxNumOfHintsInEachColumn.toDouble() - 1) * _borderWidth) * ratioOfScreenToPuzzle;
-  Widget buildViewArea() {
-    return Consumer<PlayViewModel>(builder: (context, model, _) {
-      return Positioned(
-        left: viewAreaLeftOffset,
-        top: viewAreaTopOffset,
-        width: viewAreaWidth,
-        height: viewAreaHeight,
-        child: Container(
-            padding: EdgeInsets.all(2),
-            decoration: BoxDecoration(
-              color: nonMarkedColor,
-            ),
-            child: GridView.builder(
-                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: boardColumnsNum,
-                ),
-                itemCount: boardColumnsNum * boardRowsNum,
-                physics: const NeverScrollableScrollPhysics(),
-                itemBuilder: (context, index) {
-                  return Container(
-                    decoration: BoxDecoration(
-                      color: model.logicPuzzle.lastState[index] == 1
-                          ? markedColor
-                          : nonMarkedColor,
-                    ),
-                    child: Text(''),
-                  );
-                })),
-      );
-    });
-  }
-
-  int get _columnHintsAreaBoldBorderNum => (boardColumnsNum - 1) ~/ boldBorderInterval;
-  int get _columnHintsAreaBorderNum => boardColumnsNum - _columnHintsAreaBoldBorderNum - 1;
-  double get columnHintsAreaLeftOffset => viewAreaLeftOffset + viewAreaWidth + _boldBorderWidth * ratioOfScreenToPuzzle;
-  double get columnHintsAreaTopOffset => _boldBorderWidth * ratioOfScreenToPuzzle;
-  double get columnHintsAreaWidth => (_squareSize * boardColumnsNum.toDouble() + _borderWidth * _columnHintsAreaBorderNum + _boldBorderWidth * _columnHintsAreaBoldBorderNum) * ratioOfScreenToPuzzle;
-  double get columnHintsAreaHeight => (maxNumOfHintsInEachColumn.toDouble() * _squareSize + (maxNumOfHintsInEachColumn.toDouble() - 1) * _borderWidth) * ratioOfScreenToPuzzle;
-  Widget buildColumnHintsArea() {
-    return Stack(
-      children: [
-        for (int i = 0; i < boardColumnsNum; i++) 
-          for (int j = 0; j < maxNumOfHintsInEachColumn; j++)
-            buildHintSquare(
-              columnHintsAreaLeftOffset + squareSize * i + borderWidth * (i - i ~/ boldBorderInterval) + boldBorderWidth * (i ~/ boldBorderInterval),
-              columnHintsAreaTopOffset + (squareSize + borderWidth) * j,
-              squareSize,
-              squareSize,
-              hintsInEachColumn[maxNumOfHintsInEachColumn * i + j]
-            )
-      ],
-    );
-  }
-
-  int get _rowHintsAreaBoldBorderNum => (boardRowsNum - 1) ~/ boldBorderInterval;
-  int get _rowHintsAreaBorderNum => boardColumnsNum - _rowHintsAreaBoldBorderNum - 1;
-  double get rowHintsAreaLeftOffset => _boldBorderWidth * ratioOfScreenToPuzzle;
-  double get rowHintsAreaTopOffset => viewAreaTopOffset + viewAreaHeight + _boldBorderWidth * ratioOfScreenToPuzzle;
-  double get rowHintsAreaWidth => (maxNumOfHintsInEachRow.toDouble() * _squareSize + (maxNumOfHintsInEachRow.toDouble() - 1) * _borderWidth) * ratioOfScreenToPuzzle;
-  double get rowHintsAreaHeight => (_squareSize * boardRowsNum.toDouble() + _borderWidth * _rowHintsAreaBorderNum + _boldBorderWidth * _rowHintsAreaBorderNum) * ratioOfScreenToPuzzle;
-  Widget buildRowHintsArea() {
-    return Stack(
-      children: [
-        for (int i = 0; i < maxNumOfHintsInEachRow; i++) 
-          for (int j = 0; j < boardRowsNum; j++)
-            buildHintSquare(
-              rowHintsAreaLeftOffset + (squareSize + borderWidth) * i,
-              rowHintsAreaTopOffset + squareSize * j + borderWidth * (j - j ~/ boldBorderInterval) + boldBorderWidth * (j ~/ boldBorderInterval),
-              squareSize,
-              squareSize,
-              hintsInEachRow[maxNumOfHintsInEachColumn * j + i]
-            )
-      ],
-    );
-  }
-
-  int get _boardAreaRowBoldBorderNum => (boardColumnsNum - 1) ~/ boldBorderInterval;
-  int get _boardAreaColumnBoldBorderNum => (boardRowsNum - 1) ~/ boldBorderInterval;
-  int get _boardAreaRowBorderNum => boardColumnsNum - _boardAreaRowBoldBorderNum - 1;
-  int get _boardAreaColumnBorderNum => boardRowsNum - _boardAreaColumnBoldBorderNum - 1;
-  double get boardAreaLeftOffset => rowHintsAreaLeftOffset + rowHintsAreaWidth + _boldBorderWidth * ratioOfScreenToPuzzle;
-  double get boardAreaTopOffset => columnHintsAreaTopOffset + columnHintsAreaHeight + _boldBorderWidth * ratioOfScreenToPuzzle;
-  double get boardAreaWidth => (_squareSize * boardColumnsNum.toDouble() + borderWidth * _boardAreaRowBorderNum + boldBorderWidth * _boardAreaRowBoldBorderNum) * ratioOfScreenToPuzzle;
-  double get boardAreaHeight => (_squareSize * boardRowsNum.toDouble() + borderWidth * _boardAreaColumnBorderNum + boldBorderWidth * _boardAreaColumnBoldBorderNum) * ratioOfScreenToPuzzle;
-  Widget buildBoardArea() {
-    return Consumer<PlayViewModel>(builder: (context, model, _) {
-      return Stack(
-        children: [
-          for (int i = 0; i < boardColumnsNum; i++) 
-            for (int j = 0; j < boardRowsNum; j++)
-              buildInputSquare(
-                boardAreaLeftOffset + squareSize * i + borderWidth * (i - i ~/ boldBorderInterval) + boldBorderWidth * (i ~/ boldBorderInterval),
-                boardAreaTopOffset + squareSize * j + borderWidth * (j - j ~/ boldBorderInterval) + boldBorderWidth * (j ~/ boldBorderInterval),
-                squareSize,
-                squareSize,
-                boardColumnsNum * j + i
-              )
-        ],
-      );
-    });
-  }
-
-  Widget buildHintSquare(double left, double top, double width, double height, int hintNum) {
-    return Positioned(
-      left: left,
-      top: top,
-      width: width,
-      height: height,
-      child: Container(
-        decoration: BoxDecoration(
-          color: hintBackgroundColor
-        ),
-        child: FittedBox(
-          child: hintNum != 0
-            ? Text(
-              '${hintNum}',
-              style: TextStyle(fontWeight: FontWeight.bold),
-            )
-            : Text(''),
-        )
-      )
-    );
-  }
-
-  Widget buildInputSquare(double left, double top, double width, double height, int index) {
-    return Consumer<PlayViewModel>(builder: (context, model, _) {
-      return Positioned(
-        left: left,
-        top: top,
-        width: width,
-        height: height,
-        child: GestureDetector(
-          child: Container(
-            decoration: BoxDecoration(
-              color: nonMarkedColor,
-            ),
-            child: ((){ 
-              switch (model.logicPuzzle.lastState[index]) {
-                case 0:
-                  return Container(
-                    margin: EdgeInsets.all(2),
-                    decoration: BoxDecoration(
-                      color: nonMarkedColor,
-                    ),
-                    child: Text(''),
-                  );
-                case 1:
-                  return Container(
-                    margin: EdgeInsets.all(2),
-                    decoration: BoxDecoration(
-                      color: markedColor,
-                    ),
-                    child: Text(''),
-                  );
-                case 2:
-                  return Container(
-                    margin: EdgeInsets.all(2),
-                    child: Icon(                        
-                      IconData(57704, fontFamily: 'MaterialIcons'),
-                          color: markedColor,
-                      ),
-                  );
-              }
-            })(),
-          ),
-          onTap: () {
-            if (model.logicPuzzle.lastState[index] == 0) {                
-              switch (model.operationMethodIndex) {
-                case 0:
-                  model.logicPuzzle.lastState[index] = 1;
-                  break;
-                case 1:
-                  model.logicPuzzle.lastState[index] = 2;
-                  break;
-              }
-            } else {
-              model.logicPuzzle.lastState[index] = 0;
-            }
-            model.save();
-            model.notify();
-          },
-        ),
-      );
-    });
+    context.read<PlayViewModel>().inputSquareLocalPointsList = getInputSquareLocalPointsList();
   }
 
   bool isCorrect() {
@@ -538,24 +291,55 @@ class Puzzle extends StatelessWidget {
       .toList()
       .map((e) => e.key)
       .toList();
-    List<int> userCheckedList = context.read<PlayViewModel>().checkedList;
+    LogicPuzzle logicPuzzle = context.read<PlayViewModel>().logicPuzzle;
+    List<int> userCheckedList = [];
+    logicPuzzle.lastState.asMap().forEach((int i, int value) {
+      if (value == 1) userCheckedList.add(i);
+    });
     answerCheckedList.sort((a, b) => a - b);
     userCheckedList.sort((a, b) => a - b);
     return listEquals(answerCheckedList, userCheckedList);
   }
+
+  List<List<Offset>> getInputSquareLocalPointsList() {
+    List<List<Offset>> inputSquarePointsList = [];
+    for (int j = 0; j < boardRowsNum; j++) {
+      for (int i = 0; i < boardColumnsNum; i++) {
+        Offset upperLeftOffset = Offset(
+          boardAreaLeftOffset + squareSize * i + borderWidth * (i - i ~/ boldBorderInterval) + boldBorderWidth * (i ~/ boldBorderInterval),
+          boardAreaTopOffset + squareSize * j + borderWidth * (j - j ~/ boldBorderInterval) + boldBorderWidth * (j ~/ boldBorderInterval)
+        );
+        Offset lowerRightOffset = upperLeftOffset + Offset(squareSize, squareSize);
+        List<Offset> inputSquarePoints = [upperLeftOffset, lowerRightOffset];
+        inputSquarePointsList.add(inputSquarePoints);
+      }
+    }
+    return inputSquarePointsList;
+  }
 }
 
-class PuzzleSetting {
-  // TODO: move to settinig(const variables) file
-  static const double squareSize = 10.0;
-  static const double borderWidth = 0.8;
-  static const double boldBorderWidth = 1.5;
-  static const int boldBorderInterval = 5;
-  static const Color borderColor = Colors.black;
-  static const Color boldBorderColor = Colors.black;
-  //static final Color hintBackgroundColor = Colors.blue[50];
-  static const Color hintBackgroundColor = Color(0xFFE3F2FD);
-  //static final Color markedColor = Colors.blue[500];
-  static const Color markedColor = Color(0xFF2196F3);
-  static const Color nonMarkedColor = Colors.white;
+class PuzzleUpdatePainter extends PuzzlePainter {
+  final BuildContext context;
+  final List<int> state;
+  PuzzleUpdatePainter({this.context, this.state}) :super(context: context, logicPuzzle: context.read<PlayViewModel>().logicPuzzle);
+
+  @override
+  void paint(Canvas canvas, Size size) async {
+    int tappedSquareIndex = context.read<PlayViewModel>().tappedSquaeIndex;
+    ui.Image puzzleImage = context.read<PlayViewModel>().puzzleImage;
+
+    final paint = Paint();
+    canvas.drawImage(puzzleImage, Offset(0, 0), paint);
+    if (tappedSquareIndex!=null) {
+      drawState(canvas, tappedSquareIndex, state[tappedSquareIndex]);
+      drawStateInViewArea(canvas, tappedSquareIndex, state[tappedSquareIndex]);
+    }
+
+    context.read<PlayViewModel>().isDrawImage = true;
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) {
+    return true;
+  }
 }

--- a/lib/ui/play/play_view_model.dart
+++ b/lib/ui/play/play_view_model.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui;
+
 import 'package:ant_1/domain/dao/logic_puzzle_dao.dart';
 import 'package:ant_1/domain/entities/logic_puzzle.dart';
 import 'package:flutter/foundation.dart';
@@ -10,8 +12,13 @@ class PlayViewModel with ChangeNotifier {
   Offset sessionOffset;
   double scale;
   int operationMethodIndex;
+  List<List<Offset>> inputSquareLocalPointsList;
   Function isCorrect;
   LogicPuzzleDao logicPuzzleDao;
+  ui.Image puzzleImage;
+  int tappedSquaeIndex;
+  bool isBuildedOnce;
+  bool isDrawImage;
   final List<int> checkedList = [];
   void init() {
     offset = Offset.zero;
@@ -19,6 +26,8 @@ class PlayViewModel with ChangeNotifier {
     sessionOffset = Offset.zero;
     scale = 0.9;
     operationMethodIndex = 0;
+    isBuildedOnce = false;
+    isDrawImage= false;
     logicPuzzleDao = LogicPuzzleDao();
     checkedList.removeWhere((_) => true);
     logicPuzzle.lastState.asMap().forEach((int i, int value) {
@@ -31,7 +40,7 @@ class PlayViewModel with ChangeNotifier {
   void save() async {
     await logicPuzzleDao.update(logicPuzzle.id, logicPuzzle);
   }
-  void notify() async {
+  void notify() {
     notifyListeners();
   }
 }


### PR DESCRIPTION
### 実装内容
* CustomPaint Widgetを用いてパズルを描画する方式に変更
* play画面の初回ビルド時（アクセス直後の画面表示）は、全てpainterの図形の組み合わせで描画
* 2回目のビルド時（操作による画面更新）は、1回目に表示したパズルを画像化したものに対して状態変化した部分だけ再描画
* 以降の再ビルドでは、2回目と同様、1つ前のビルドで表示していたパズルを画像化して、状態変化分だけ再描画