### PR TITLE
【修正】正方形のパズルしか正しく描画されない

### DIFF
--- a/lib/service/puzzle_painter.dart
+++ b/lib/service/puzzle_painter.dart
@@ -33,59 +33,18 @@ class PuzzlePainter extends CustomPainter {
   int get _maxNumOfHintsInEachColumn => hintsInEachColumn.length ~/ boardColumnsNum;
   int get maxNumOfHintsInEachColumn => _maxNumOfHintsInEachColumn > 0 ? _maxNumOfHintsInEachColumn : 1;
 
-  List<int> _hintsInEachRow() {
+  List<int> _hintsInEachRow() { // left-area hints
     List<List<int>> hints = [];
     List<int> tmp;
     int pre;
     int n;
     int maxN = 0;
-    for (int i = 0; i < boardColumnsNum; i++) {
+    for (int j = 0; j < boardRowsNum; j++) {
       tmp = [];
       pre = 0;
       n = 0;
-      for (int j = 0; j < boardRowsNum; j++) {
-        int now = answer[boardRowsNum * i + j];
-        if (now == 0) {
-          if (pre == 1) {
-            tmp.add(n);
-          }
-          n = 0;
-          pre = 0;
-        } else {
-          n++;
-          pre = 1;
-        }
-      }
-      if (n != 0) {
-        tmp.add(n);
-      }
-      maxN = max(maxN, tmp.length);
-      hints.add(tmp.reversed.toList());
-    }
-
-    List<int> result = List.generate(maxN * boardColumnsNum, (_) => 0);
-    for (int i = 0; i < boardColumnsNum; i++) {
-      List<int> hint = hints[i];
-      for (int j = 0; j < hint.length; j++) {
-        result[maxN * (i + 1) - j - 1] = hint[j];
-      }
-    }
-
-    return result;
-  }
-
-  List<int> _hintsInEachColumn() {
-    List<List<int>> hints = [];
-    List<int> tmp;
-    int pre;
-    int n;
-    int maxN = 0;
-    for (int i = 0; i < boardRowsNum; i++) {
-      tmp = [];
-      pre = 0;
-      n = 0;
-      for (int j = 0; j < boardColumnsNum; j++) {
-        int now = answer[boardRowsNum * j + i];
+      for (int i = 0; i < boardColumnsNum; i++) {
+        int now = answer[boardColumnsNum * j + i];
         if (now == 0) {
           if (pre == 1) {
             tmp.add(n);
@@ -106,6 +65,47 @@ class PuzzlePainter extends CustomPainter {
 
     List<int> result = List.generate(maxN * boardRowsNum, (_) => 0);
     for (int i = 0; i < boardRowsNum; i++) {
+      List<int> hint = hints[i];
+      for (int j = 0; j < hint.length; j++) {
+        result[maxN * (i + 1) - j - 1] = hint[j];
+      }
+    }
+
+    return result;
+  }
+
+  List<int> _hintsInEachColumn() { // upper-area hints
+    List<List<int>> hints = [];
+    List<int> tmp;
+    int pre;
+    int n;
+    int maxN = 0;
+    for (int j = 0; j < boardColumnsNum; j++) {
+      tmp = [];
+      pre = 0;
+      n = 0;
+      for (int i = 0; i < boardRowsNum; i++) {
+        int now = answer[boardColumnsNum * i + j];
+        if (now == 0) {
+          if (pre == 1) {
+            tmp.add(n);
+          }
+          n = 0;
+          pre = 0;
+        } else {
+          n++;
+          pre = 1;
+        }
+      }
+      if (n != 0) {
+        tmp.add(n);
+      }
+      maxN = max(maxN, tmp.length);
+      hints.add(tmp.reversed.toList());
+    }
+
+    List<int> result = List.generate(maxN * boardColumnsNum, (_) => 0);
+    for (int i = 0; i < boardColumnsNum; i++) {
       List<int> hint = hints[i];
       for (int j = 0; j < hint.length; j++) {
         result[maxN * (i + 1) - j - 1] = hint[j];
@@ -209,8 +209,8 @@ class PuzzlePainter extends CustomPainter {
   Size get rowHintsAreaSize => Size(rowHintsAreaWidth, rowHintsAreaHeight);
   void drawRowHintsArea(Canvas canvas) {
     Size size = Size(squareSize, squareSize);
-    for (int i = 0; i < maxNumOfHintsInEachRow; i++) {
       for (int j = 0; j < boardRowsNum; j++) {
+    for (int i = 0; i < maxNumOfHintsInEachRow; i++) {
         Offset offset = Offset(
           rowHintsAreaLeftOffset + (squareSize + borderWidth) * i,
           rowHintsAreaTopOffset + squareSize * j + borderWidth * (j - j ~/ boldBorderInterval) + boldBorderWidth * (j ~/ boldBorderInterval)

--- a/lib/ui/create/confirm_screen.dart
+++ b/lib/ui/create/confirm_screen.dart
@@ -41,11 +41,12 @@ class ConfirmScreen extends StatelessWidget {
       compImage: dotImage,
     );
 
-    final Size boardSize = Size(size.width, size.width);
-    CustomPainter boardPainter = PuzzlePainter(
+    PuzzlePainter boardPainter = PuzzlePainter(
       context: context,
       logicPuzzle: compLogic,
     );
+    // final Size boardSize = Size(size.width, size.width);
+    Size boardSize = Size(boardPainter.borderLayerWidth, boardPainter.borderLayerHeight);
 
     Future _saveImage(Uint8List dotImage) async {
       await ImageGallerySaver.saveImage(dotImage, quality: 100);

--- a/lib/ui/play/play_screen.dart
+++ b/lib/ui/play/play_screen.dart
@@ -152,12 +152,12 @@ class PlayScreen extends StatelessWidget {
   }
 
   Widget buildInitPuzzle(BuildContext context, GlobalKey widgetKey) {
-    Size size = Size(MediaQuery.of(context).size.width, MediaQuery.of(context).size.width);
     PuzzleInitPainter painter = PuzzleInitPainter(
       context: context,
       state: context.read<PlayViewModel>().logicPuzzle.lastState,
       puzzleImage: context.read<PlayViewModel>().puzzleImage
     );
+    Size size = Size(painter.borderLayerWidth, painter.borderLayerHeight);
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       context.read<PlayViewModel>().puzzleImage = await getImageFromPainter(painter, size);
@@ -177,11 +177,11 @@ class PlayScreen extends StatelessWidget {
   Widget buildPuzzle(BuildContext context, GlobalKey widgetKey) {
     return Consumer<PlayViewModel>(
       builder: (context, model, child) {
-        Size size = Size(MediaQuery.of(context).size.width, MediaQuery.of(context).size.width);
         PuzzleUpdatePainter painter = PuzzleUpdatePainter(
           context: context,
           state: model.logicPuzzle.lastState
         );
+        Size size = Size(painter.borderLayerWidth, painter.borderLayerHeight);
         if (context.read<PlayViewModel>().isBuildedOnce && model.tappedSquaeIndex != null) {
           WidgetsBinding.instance.addPostFrameCallback((_) async {
             context.read<PlayViewModel>().puzzleImage = await getImageFromPainter(painter, size);

--- a/lib/ui/top/top_screen.dart
+++ b/lib/ui/top/top_screen.dart
@@ -1,4 +1,5 @@
 import 'package:ant_1/domain/entities/logic_puzzle.dart';
+import 'package:ant_1/service/puzzle_painter.dart';
 import 'package:ant_1/ui/create/init_create_screen.dart';
 import 'package:ant_1/ui/play/play_view_model.dart';
 import 'package:ant_1/ui/top/top_view_model.dart';
@@ -114,17 +115,18 @@ class TopScreen extends StatelessWidget {
                                               .logicPuzzle =
                                           model.logicPuzzles[index];
                                       context.read<PlayViewModel>().init();
+                                      PuzzlePainter puzzlePainter = PuzzlePainter(context: context, logicPuzzle: model.logicPuzzles[index]);
                                       ui.Codec codecImage =
                                           await ui.instantiateImageCodec(
                                         model.logicPuzzles[index].stateList,
-                                        targetWidth: (size.width).floor(),
+                                        targetWidth: (puzzlePainter.borderLayerWidth).floor(),
+                                        targetHeight: (puzzlePainter.borderLayerHeight).floor(),
                                       );
                                       ui.FrameInfo frame =
                                           await codecImage.getNextFrame();
                                       ui.Image image = frame.image;
-                                      context
-                                          .read<PlayViewModel>()
-                                          .puzzleImage = image;
+                                      // context.read<PlayViewModel>().puzzleImage = null;
+                                      context.read<PlayViewModel>().puzzleImage = image;
                                       Navigator.of(context).pushNamed('/play');
                                     },
                                     child: Dismissible(


### PR DESCRIPTION
### 実装内容
* パズルが縦長の場合に強制的に正方形で描画されてしまう問題を修正
*  正方形以外のパズルの場合にヒントの数字が間違っている問題を修正
